### PR TITLE
refactor

### DIFF
--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -3,13 +3,8 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"log"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/google/go-github/v59/github"
@@ -87,169 +82,14 @@ func (g *GitHubVCS) Backup(ctx context.Context) error {
 	}
 
 	// Backup repositories
-	repos, err := g.listRepositories(ctx, username)
-	if err != nil {
-		return fmt.Errorf("failed to list repositories: %w", err)
+	if err := g.backupRepositories(ctx, username); err != nil {
+		return fmt.Errorf("failed to backup repositories: %w", err)
 	}
 
 	// Backup gists if configured to do so
 	if g.config.IncludeGists {
-		gists, err := g.listGists(ctx, username)
-		if err != nil {
-			return fmt.Errorf("failed to list gists: %w", err)
-		}
-		log.Printf("Found %d gists for user %s\n", len(gists), username)
-
-		// Create the gists directory if it doesn't exist
-		gistsDir := filepath.Join(g.config.OutputDir, "gists")
-		if err := os.MkdirAll(gistsDir, 0755); err != nil {
-			return fmt.Errorf("failed to create gists directory: %w", err)
-		}
-
-		// Backup gists
-		gistErrChan := make(chan error, len(gists))
-		gistSemaphore := make(chan struct{}, g.config.Threads)
-
-		for _, gist := range gists {
-			if gist.ID == nil {
-				gistErrChan <- fmt.Errorf("gist has no ID")
-				continue
-			}
-
-			gistSemaphore <- struct{}{} // Acquire semaphore
-			go func(gist *github.Gist) {
-				defer func() { <-gistSemaphore }() // Release semaphore when done
-
-				// Create gist directory
-				gistDir := filepath.Join(gistsDir, *gist.ID)
-				if err := os.MkdirAll(gistDir, 0755); err != nil {
-					gistErrChan <- fmt.Errorf("failed to create gist directory %s: %w", *gist.ID, err)
-					return
-				}
-
-				// Save gist metadata
-				metadataFile := filepath.Join(gistDir, "gist.json")
-				metadata, err := json.MarshalIndent(gist, "", "  ")
-				if err != nil {
-					gistErrChan <- fmt.Errorf("failed to marshal gist metadata %s: %w", *gist.ID, err)
-					return
-				}
-
-				if err := os.WriteFile(metadataFile, metadata, 0644); err != nil {
-					gistErrChan <- fmt.Errorf("failed to save gist metadata %s: %w", *gist.ID, err)
-					return
-				}
-
-				// Save each file in the gist
-				for _, file := range gist.Files {
-					// Skip files without a filename
-					if file.Filename == nil {
-						log.Printf("Skipping gist file with no filename in gist %s", *gist.ID)
-						continue
-					}
-
-					// Get the filename safely
-					filenameStr := *file.Filename
-
-					// Get file content (might be nil for large files)
-					var content string
-					if file.Content != nil {
-						content = *file.Content
-					} else if file.RawURL != nil {
-						// Try to fetch the content from RawURL
-						resp, err := http.Get(*file.RawURL)
-						if err != nil {
-							log.Printf("Failed to fetch content for large file %s: %v", filenameStr, err)
-							continue
-						}
-						defer resp.Body.Close()
-
-						if resp.StatusCode != http.StatusOK {
-							log.Printf("Failed to fetch content for %s: %s", filenameStr, resp.Status)
-							continue
-						}
-
-						contentBytes, err := io.ReadAll(resp.Body)
-						if err != nil {
-							log.Printf("Failed to read content for %s: %v", filenameStr, err)
-							continue
-						}
-						content = string(contentBytes)
-					}
-
-					// Create necessary subdirectories
-					filePath := filepath.Join(gistDir, filenameStr)
-					dir := filepath.Dir(filePath)
-					if dir != "." {
-						if err := os.MkdirAll(dir, 0755); err != nil {
-							gistErrChan <- fmt.Errorf("failed to create directory for gist file %s: %w", filenameStr, err)
-							continue
-						}
-					}
-
-					// Write file content
-					if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-						gistErrChan <- fmt.Errorf("failed to save gist file %s: %w", filenameStr, err)
-						continue
-					}
-				}
-
-				log.Printf("Successfully backed up gist: %s\n", *gist.ID)
-				gistErrChan <- nil
-			}(gist)
-
-			// Check if context is done
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				// Continue with the next gist
-			}
-		}
-
-		// Wait for all gist backups to complete
-		for i := 0; i < len(gists); i++ {
-			if err := <-gistErrChan; err != nil {
-				log.Printf("Error during gist backup: %v", err)
-			}
-		}
-	}
-
-	log.Printf("Found %d repositories for user %s\n", len(repos), username)
-
-	// Create repositories directory
-	reposDir := filepath.Join(g.config.OutputDir, "repos")
-	if err := os.MkdirAll(reposDir, 0755); err != nil {
-		return fmt.Errorf("failed to create repositories directory: %w", err)
-	}
-
-	// Backup repositories
-	errChan := make(chan error, len(repos))
-	semaphore := make(chan struct{}, g.config.Threads)
-
-	for _, repo := range repos {
-		semaphore <- struct{}{} // Acquire semaphore
-		go func(r *github.Repository) {
-			defer func() { <-semaphore }() // Release semaphore when done
-
-			if r.Name == nil {
-				errChan <- fmt.Errorf("repository has no name")
-				return
-			}
-
-			if err := g.cloneRepository(ctx, r, reposDir); err != nil {
-				errChan <- fmt.Errorf("failed to backup repository %s: %w", *r.Name, err)
-				return
-			}
-
-			errChan <- nil
-		}(repo)
-	}
-
-	// Wait for all goroutines to complete
-	for i := 0; i < len(repos); i++ {
-		if err := <-errChan; err != nil {
-			log.Printf("Error during backup: %v", err)
+		if err := g.backupGists(ctx, username); err != nil {
+			return fmt.Errorf("failed to backup gists: %w", err)
 		}
 	}
 

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -255,14 +255,3 @@ func (g *GitHubVCS) Backup(ctx context.Context) error {
 
 	return nil
 }
-
-// getAuthType returns the authentication type based on configuration.
-func (g *GitHubVCS) getAuthType() string {
-	if g.config.NoAuth {
-		return "none"
-	}
-	if g.config.Token != "" {
-		return "token"
-	}
-	return "anonymous"
-}

--- a/internal/vcs/github/gists.go
+++ b/internal/vcs/github/gists.go
@@ -2,7 +2,13 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/google/go-github/v59/github"
 )
@@ -71,4 +77,177 @@ func (g *GitHubVCS) listGistsPage(ctx context.Context, username string, opt *git
 	}
 
 	return userGists, resp, nil
+}
+
+// backupGists orchestrates the backup of all gists for a user.
+func (g *GitHubVCS) backupGists(ctx context.Context, username string) error {
+	gists, err := g.listGists(ctx, username)
+	if err != nil {
+		return fmt.Errorf("failed to list gists: %w", err)
+	}
+
+	log.Printf("Found %d gists for user %s\n", len(gists), username)
+
+	// Create the gists directory if it doesn't exist
+	gistsDir := filepath.Join(g.config.OutputDir, "gists")
+	if err := os.MkdirAll(gistsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create gists directory: %w", err)
+	}
+
+	// Backup gists concurrently
+	gistErrChan := make(chan error, len(gists))
+	gistSemaphore := make(chan struct{}, g.config.Threads)
+
+	for _, gist := range gists {
+		if gist.ID == nil {
+			gistErrChan <- fmt.Errorf("gist has no ID")
+			continue
+		}
+
+		gistSemaphore <- struct{}{} // Acquire semaphore
+		go func(gist *github.Gist) {
+			defer func() { <-gistSemaphore }() // Release semaphore when done
+
+			if err := g.backupSingleGist(gist, gistsDir); err != nil {
+				gistErrChan <- fmt.Errorf("failed to backup gist %s: %w", *gist.ID, err)
+				return
+			}
+
+			log.Printf("Successfully backed up gist: %s\n", *gist.ID)
+			gistErrChan <- nil
+		}(gist)
+
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			// Continue with the next gist
+		}
+	}
+
+	// Wait for all gist backups to complete
+	for i := 0; i < len(gists); i++ {
+		if err := <-gistErrChan; err != nil {
+			log.Printf("Error during gist backup: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// backupSingleGist backs up a single gist to the specified directory.
+func (g *GitHubVCS) backupSingleGist(gist *github.Gist, baseDir string) error {
+	if gist.ID == nil {
+		return fmt.Errorf("gist has no ID")
+	}
+
+	// Create gist directory
+	gistDir := filepath.Join(baseDir, *gist.ID)
+	if err := os.MkdirAll(gistDir, 0755); err != nil {
+		return fmt.Errorf("failed to create gist directory %s: %w", *gist.ID, err)
+	}
+
+	// Save gist metadata
+	if err := g.saveGistMetadata(gist, gistDir); err != nil {
+		return fmt.Errorf("failed to save gist metadata: %w", err)
+	}
+
+	// Save each file in the gist
+	if err := g.saveGistFiles(gist, gistDir); err != nil {
+		return fmt.Errorf("failed to save gist files: %w", err)
+	}
+
+	return nil
+}
+
+// saveGistMetadata saves the gist metadata as a JSON file.
+func (g *GitHubVCS) saveGistMetadata(gist *github.Gist, gistDir string) error {
+	metadataFile := filepath.Join(gistDir, "gist.json")
+	metadata, err := json.MarshalIndent(gist, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal gist metadata: %w", err)
+	}
+
+	if err := os.WriteFile(metadataFile, metadata, 0644); err != nil {
+		return fmt.Errorf("failed to save gist metadata: %w", err)
+	}
+
+	return nil
+}
+
+// saveGistFiles saves all files in a gist to the specified directory.
+func (g *GitHubVCS) saveGistFiles(gist *github.Gist, gistDir string) error {
+	for _, file := range gist.Files {
+		// Skip files without a filename
+		if file.Filename == nil {
+			log.Printf("Skipping gist file with no filename in gist %s", *gist.ID)
+			continue
+		}
+
+		if err := g.saveGistFile(file, gistDir); err != nil {
+			log.Printf("Failed to save gist file %s: %v", *file.Filename, err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// saveGistFile saves a single gist file to the specified directory.
+func (g *GitHubVCS) saveGistFile(file github.GistFile, gistDir string) error {
+	// Get the filename safely
+	filenameStr := *file.Filename
+
+	// Get file content (might be nil for large files)
+	content, err := g.getGistFileContent(file)
+	if err != nil {
+		return fmt.Errorf("failed to get content for file %s: %w", filenameStr, err)
+	}
+
+	// Create necessary subdirectories
+	filePath := filepath.Join(gistDir, filenameStr)
+	dir := filepath.Dir(filePath)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory for gist file %s: %w", filenameStr, err)
+		}
+	}
+
+	// Write file content
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to save gist file %s: %w", filenameStr, err)
+	}
+
+	return nil
+}
+
+// getGistFileContent retrieves the content of a gist file.
+func (g *GitHubVCS) getGistFileContent(file github.GistFile) (string, error) {
+	// Get file content (might be nil for large files)
+	if file.Content != nil {
+		return *file.Content, nil
+	}
+
+	if file.RawURL != nil {
+		// Try to fetch the content from RawURL
+		resp, err := http.Get(*file.RawURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch content for large file: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("failed to fetch content: %s", resp.Status)
+		}
+
+		contentBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("failed to read content: %w", err)
+		}
+
+		return string(contentBytes), nil
+	}
+
+	return "", fmt.Errorf("no content available for file")
 }

--- a/internal/vcs/github/gists.go
+++ b/internal/vcs/github/gists.go
@@ -2,11 +2,7 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log"
-	"os"
-	"path/filepath"
 
 	"github.com/google/go-github/v59/github"
 )
@@ -75,115 +71,4 @@ func (g *GitHubVCS) listGistsPage(ctx context.Context, username string, opt *git
 	}
 
 	return userGists, resp, nil
-}
-
-// backupGists backs up all gists for the given username.
-func (g *GitHubVCS) backupGists(ctx context.Context, username string) error {
-	gists, err := g.listGists(ctx, username)
-	if err != nil {
-		return fmt.Errorf("failed to list gists: %w", err)
-	}
-
-	if len(gists) == 0 {
-		log.Println("No gists found to back up")
-		return nil
-	}
-
-	log.Printf("Found %d gists for user %s\n", len(gists), username)
-
-	// Create gists directory if it doesn't exist
-	gistsDir := filepath.Join(g.config.OutputDir, "gists")
-	if err := os.MkdirAll(gistsDir, 0755); err != nil {
-		return fmt.Errorf("failed to create gists directory: %w", err)
-	}
-
-	errChan := make(chan error, len(gists))
-	semaphore := make(chan struct{}, g.config.Threads)
-
-	for _, gist := range gists {
-		if gist.ID == nil {
-			errChan <- fmt.Errorf("gist has no ID")
-			continue
-		}
-
-		semaphore <- struct{}{} // Acquire semaphore
-		go func(gist *github.Gist) {
-			defer func() { <-semaphore }() // Release semaphore when done
-
-			// Create gist directory
-			gistDir := filepath.Join(gistsDir, *gist.ID)
-			if err := os.MkdirAll(gistDir, 0755); err != nil {
-				errChan <- fmt.Errorf("failed to create gist directory %s: %w", *gist.ID, err)
-				return
-			}
-
-			// Save gist metadata
-			metadataFile := filepath.Join(gistDir, "gist.json")
-			metadata, err := json.MarshalIndent(gist, "", "  ")
-			if err != nil {
-				errChan <- fmt.Errorf("failed to marshal gist metadata %s: %w", *gist.ID, err)
-				return
-			}
-
-			if err := os.WriteFile(metadataFile, metadata, 0644); err != nil {
-				errChan <- fmt.Errorf("failed to save gist metadata %s: %w", *gist.ID, err)
-				return
-			}
-
-			// Save each file in the gist
-			for filename, file := range gist.Files {
-				// Skip invalid files
-				if file.Filename == nil {
-					continue
-				}
-
-				// Get file content (might be nil for large files)
-				content := ""
-				if file.Content != nil {
-					content = *file.Content
-				} else if file.RawURL != nil {
-					// For large files, we'd need to fetch the content from RawURL
-					// This is a simplified version - in production, you'd want to handle this properly
-					log.Printf("Skipping large file %s (content not included in gist response)", *file.Filename)
-					continue
-				}
-
-				// Create necessary subdirectories
-				filePath := filepath.Join(gistDir, *file.Filename)
-				dir := filepath.Dir(filePath)
-				if dir != "." {
-					if err := os.MkdirAll(dir, 0755); err != nil {
-						errChan <- fmt.Errorf("failed to create directory for gist file %s: %w", filename, err)
-						continue
-					}
-				}
-
-				// Write file content
-				if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-					errChan <- fmt.Errorf("failed to save gist file %s: %w", filename, err)
-					continue
-				}
-			}
-
-			log.Printf("Successfully backed up gist: %s\n", *gist.ID)
-			errChan <- nil
-		}(gist)
-
-		// Check if context is done
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			// Continue with the next gist
-		}
-	}
-
-	// Wait for all goroutines to complete
-	for i := 0; i < len(gists); i++ {
-		if err := <-errChan; err != nil {
-			log.Printf("Error during gist backup: %v", err)
-		}
-	}
-
-	return nil
 }

--- a/internal/vcs/github/repos.go
+++ b/internal/vcs/github/repos.go
@@ -79,13 +79,13 @@ func (g *GitHubVCS) cloneRepository(ctx context.Context, repo *github.Repository
 		return fmt.Errorf("failed to create directory %s: %w", baseDir, err)
 	}
 
-	// Build the git clone command
+	// Build the git clone URL
 	cloneURL := *repo.CloneURL
 	if g.config.Token != "" {
-		// Use SSH URL if we have a token (for private repos)
-		if repo.SSHURL != nil {
-			cloneURL = *repo.SSHURL
-		}
+		// Use token based URL if we have a token (for private repos)
+		// https://<token>@<repo-url>
+		cloneURL = fmt.Sprintf("https://%s@%s", g.config.Token, strings.TrimPrefix(*repo.CloneURL, "https://"))
+
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", cloneURL, *repo.Name)


### PR DESCRIPTION
- Remove unused getAuthType helper from GitHub client
- Remove gist backup and unused imports
 Extract repository & gist backup flows into a helper
- Use tokenized HTTPS clone URL for private repositories (replace SSH usage)