### PR TITLE
feat(github): include private repos/gists and use token via http.extraHeader for git ops

### DIFF
--- a/internal/vcs/github/gists.go
+++ b/internal/vcs/github/gists.go
@@ -51,9 +51,8 @@ func (g *GitHubVCS) listGists(ctx context.Context, username string) ([]*github.G
 
 // listGistsPage fetches a single page of gists.
 func (g *GitHubVCS) listGistsPage(ctx context.Context, username string, opt *github.GistListOptions) ([]*github.Gist, *github.Response, error) {
-	if g.config.NoAuth || g.config.User == username {
-		// In no-auth mode or when listing our own gists,
-		// we can use the simpler List API.
+	// When unauthenticated, List(username) returns only public gists
+	if g.config.NoAuth || g.config.Token == "" {
 		gists, resp, err := g.client.Gists.List(ctx, username, opt)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to list gists for user %s: %w", username, err)
@@ -61,22 +60,13 @@ func (g *GitHubVCS) listGistsPage(ctx context.Context, username string, opt *git
 		return gists, resp, nil
 	}
 
-	// For authenticated requests, we need to list all gists and filter them
-	// since GitHub API doesn't support searching gists by user in the same way as repositories.
-	gists, resp, err := g.client.Gists.ListAll(ctx, opt)
+	// When authenticated, use empty username to fetch the authenticated user's gists,
+	// which includes private gists.
+	gists, resp, err := g.client.Gists.List(ctx, "", opt)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list all gists: %w", err)
+		return nil, nil, fmt.Errorf("failed to list authenticated user's gists: %w", err)
 	}
-
-	// Filter gists by owner
-	var userGists []*github.Gist
-	for _, gist := range gists {
-		if gist.Owner != nil && gist.Owner.Login != nil && *gist.Owner.Login == username {
-			userGists = append(userGists, gist)
-		}
-	}
-
-	return userGists, resp, nil
+	return gists, resp, nil
 }
 
 // backupGists orchestrates the backup of all gists for a user.

--- a/internal/vcs/github/repos.go
+++ b/internal/vcs/github/repos.go
@@ -3,12 +3,12 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/google/go-github/v59/github"
@@ -25,7 +25,17 @@ func (g *GitHubVCS) listRepositories(ctx context.Context, username string) ([]*g
 	}
 
 	for {
-		repos, resp, err := g.client.Repositories.List(ctx, username, opts)
+		// If authenticated (token present), use the authenticated user's endpoint to include private repos
+		var (
+			repos []*github.Repository
+			resp  *github.Response
+			err   error
+		)
+		if g.config.Token != "" && !g.config.NoAuth {
+			repos, resp, err = g.client.Repositories.List(ctx, "", opts)
+		} else {
+			repos, resp, err = g.client.Repositories.List(ctx, username, opts)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("error listing repositories: %w", err)
 		}
@@ -60,6 +70,14 @@ func (g *GitHubVCS) checkRateLimit(resp *github.Response) error {
 	return nil
 }
 
+// basicAuthHeader builds an Authorization header value suitable for Git over HTTPS with a PAT.
+// GitHub expects Basic auth with username "x-access-token" and the token as the password.
+func (g *GitHubVCS) basicAuthHeader() string {
+	creds := "x-access-token:" + g.config.Token
+	b64 := base64.StdEncoding.EncodeToString([]byte(creds))
+	return "Authorization: Basic " + b64
+}
+
 // cloneRepository clones a single repository to the specified directory.
 func (g *GitHubVCS) cloneRepository(ctx context.Context, repo *github.Repository, baseDir string) error {
 	if repo == nil || repo.CloneURL == nil || repo.Name == nil {
@@ -79,16 +97,13 @@ func (g *GitHubVCS) cloneRepository(ctx context.Context, repo *github.Repository
 		return fmt.Errorf("failed to create directory %s: %w", baseDir, err)
 	}
 
-	// Build the git clone URL
-	cloneURL := *repo.CloneURL
+	// Build the git clone command using HTTPS and pass token via http.extraHeader (Basic auth)
+	args := []string{"clone", "--mirror"}
 	if g.config.Token != "" {
-		// Use token based URL if we have a token (for private repos)
-		// https://<token>@<repo-url>
-		cloneURL = fmt.Sprintf("https://%s@%s", g.config.Token, strings.TrimPrefix(*repo.CloneURL, "https://"))
-
+		args = append([]string{"-c", "http.extraHeader=" + g.basicAuthHeader()}, args...)
 	}
-
-	cmd := exec.CommandContext(ctx, "git", "clone", "--mirror", cloneURL, *repo.Name)
+	args = append(args, *repo.CloneURL, *repo.Name)
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = baseDir
 
 	// Set up output capture
@@ -104,7 +119,11 @@ func (g *GitHubVCS) cloneRepository(ctx context.Context, repo *github.Repository
 // pullRepository updates an existing repository
 func (g *GitHubVCS) pullRepository(repoDir string) error {
 	// Change to the repository directory
-	cmd := exec.Command("git", "remote", "update", "--prune")
+	args := []string{"remote", "update", "--prune"}
+	if g.config.Token != "" {
+		args = append([]string{"-c", "http.extraHeader=" + g.basicAuthHeader()}, args...)
+	}
+	cmd := exec.Command("git", args...)
 	cmd.Dir = repoDir
 
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Summary
- Include private repositories and gists in GitHub content listing and operations
- Use token provided via git http.extraHeader for Git operations instead of other auth methods

Changes
- Expand GitHub API usage to return and handle private repos and gists
- Modify git operations to extract and use authentication token from http.extraHeader

Related issues
- None specified

Notes
- Authentication now relies on git configuration header (http.extraHeader) for token-based git ops